### PR TITLE
Fix 'ratio_clear' int rounding error.

### DIFF
--- a/ccd/qa.py
+++ b/ccd/qa.py
@@ -154,7 +154,7 @@ def ratio_clear(quality):
     Returns:
         integer: number of non-fill pixels implied by QA data.
     """
-    return count_clear_or_water(quality) / count_total(quality)
+    return np.float16(count_clear_or_water(quality)) / np.float16(count_total(quality))
 
 
 def ratio_snow(quality):


### PR DESCRIPTION
`ratio_clear` was diving two ints and returning their value.  
  
Under these conditions even a high value like `int(0.99)` will always evaluate to `0`  

This means that unless you have 100% clear conditions, you're always going to be running the `insufficient_cover` procedure....  
  
This fix is as simple as casting values to floats.  

